### PR TITLE
Fix macOS terminal lifecycle and API environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "feng-claude",
-  "version": "0.7.69",
+  "version": "0.7.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feng-claude",
-      "version": "0.7.69",
+      "version": "0.7.82",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/utils": "^3.0.0",
@@ -48,7 +49,7 @@
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^4.3.1",
         "autoprefixer": "^10.4.19",
-        "electron": "^31.0.2",
+        "electron": "^43.2.0",
         "electron-builder": "^24.13.3",
         "electron-rebuild": "^3.2.9",
         "electron-vite": "^2.3.0",
@@ -396,6 +397,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron-toolkit/tsconfig": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/@electron-toolkit/tsconfig/-/tsconfig-1.0.1.tgz",
@@ -458,24 +468,57 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -2035,6 +2078,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmmirror.com/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2047,6 +2091,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmmirror.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -2114,6 +2159,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmmirror.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -2169,12 +2215,14 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmmirror.com/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmmirror.com/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2199,6 +2247,7 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2266,6 +2315,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2298,16 +2348,6 @@
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmmirror.com/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2946,14 +2986,6 @@
         "bluebird": "^3.5.5"
       }
     },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmmirror.com/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.1.0.tgz",
@@ -3039,7 +3071,9 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -3216,6 +3250,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmmirror.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
@@ -3225,6 +3260,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmmirror.com/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -3504,6 +3540,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmmirror.com/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -3875,6 +3912,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmmirror.com/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -3890,6 +3928,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3915,45 +3954,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmmirror.com/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -3991,13 +3995,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -4230,21 +4227,21 @@
       }
     },
     "node_modules/electron": {
-      "version": "31.7.7",
-      "resolved": "https://registry.npmmirror.com/electron/-/electron-31.7.7.tgz",
-      "integrity": "sha512-HZtZg8EHsDGnswFt0QeV8If8B+et63uD6RJ7I4/xhcXqmTIbI08GoubX/wm+HdY0DwcuPe1/xsgqpmYvjdjRoA==",
-      "hasInstallScript": true,
+      "version": "43.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.2.0.tgz",
+      "integrity": "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==",
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -4651,6 +4648,21 @@
         }
       }
     },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4673,6 +4685,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmmirror.com/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4707,7 +4720,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4717,7 +4730,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4751,13 +4764,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmmirror.com/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4808,19 +4814,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -4843,26 +4836,6 @@
       "resolved": "https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
     },
     "node_modules/extsprintf": {
       "version": "1.4.1",
@@ -4942,15 +4915,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/filelist": {
@@ -5072,20 +5036,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -5215,6 +5165,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmmirror.com/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -5284,59 +5235,11 @@
         "node": "*"
       }
     },
-    "node_modules/global-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/global-agent/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5349,6 +5252,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmmirror.com/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -5384,19 +5288,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -5625,6 +5516,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
@@ -5646,6 +5538,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmmirror.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -6079,6 +5972,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -6094,13 +5988,6 @@
       "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmmirror.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmmirror.com/json5/-/json5-2.2.3.tgz",
@@ -6112,15 +5999,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jszip": {
@@ -6169,6 +6047,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmmirror.com/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -6386,6 +6265,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6551,19 +6431,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/matcher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7494,6 +7361,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7853,6 +7721,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmmirror.com/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7898,20 +7767,11 @@
         "node": ">= 6"
       }
     },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7975,6 +7835,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8138,12 +7999,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8410,7 +8265,7 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmmirror.com/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "license": "MIT",
       "engines": {
@@ -8452,6 +8307,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmmirror.com/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -8493,6 +8349,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmmirror.com/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8906,12 +8763,14 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmmirror.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/responselike": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -8970,24 +8829,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/roarr": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmmirror.com/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "detect-node": "^2.0.4",
-        "globalthis": "^1.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "semver-compare": "^1.0.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/rollup": {
@@ -9119,45 +8960,10 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmmirror.com/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "type-fest": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/set-blocking": {
@@ -9326,13 +9132,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmmirror.com/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "license": "BSD-3-Clause",
-      "optional": true
     },
     "node_modules/ssf": {
       "version": "0.11.2",
@@ -9504,7 +9303,7 @@
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/sumchecker/-/sumchecker-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -9885,6 +9684,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -9998,15 +9798,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -10284,6 +10075,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -10418,16 +10210,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A third-party GUI wrapper for Claude Code CLI",
   "main": "./out/main/index.js",
   "scripts": {
-    "dev": "electron-vite dev",
+    "dev": "node scripts/dev.mjs",
     "dev:renderer": "vite src/renderer --port 5173",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
@@ -65,7 +65,7 @@
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.19",
-    "electron": "^31.0.2",
+    "electron": "^43.2.0",
     "electron-builder": "^24.13.3",
     "electron-rebuild": "^3.2.9",
     "electron-vite": "^2.3.0",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,46 @@
+import { spawn, spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const electronViteCli = join(dirname(require.resolve('electron-vite')), '..', 'bin', 'electron-vite.js')
+const electronBinary = require('electron')
+
+const child = spawn(process.execPath, [electronViteCli, 'dev'], {
+  stdio: 'inherit',
+  env: process.env
+})
+
+let stopping = false
+
+function killDevElectron(signal) {
+  if (process.platform === 'win32') return
+  // This is the project's exact Electron executable, not a broad "Electron"
+  // match, so Cursor/Chrome and other Electron applications are unaffected.
+  spawnSync('pkill', [`-${signal}`, '-f', electronBinary], { stdio: 'ignore' })
+}
+
+function stop(signal) {
+  if (stopping) return
+  stopping = true
+  child.kill(signal)
+  // electron-vite's child Electron process can outlive its parent on macOS.
+  // First offer a normal shutdown, then remove persistent dev PTY daemons.
+  setTimeout(() => killDevElectron('TERM'), 100)
+  setTimeout(() => {
+    killDevElectron('KILL')
+    process.exit(0)
+  }, 500)
+}
+
+process.on('SIGINT', () => stop('SIGINT'))
+process.on('SIGTERM', () => stop('SIGTERM'))
+
+child.on('error', (error) => {
+  console.error('[dev] failed to start electron-vite:', error.message)
+  process.exit(1)
+})
+
+child.on('exit', (code) => {
+  if (!stopping) process.exit(code ?? 1)
+})

--- a/scripts/pty-daemon.js
+++ b/scripts/pty-daemon.js
@@ -22,6 +22,7 @@
  *   Client → Server:
  *     {t:'i', d:<string>}   input to PTY
  *     {t:'r', c:<cols>, r:<rows>} resize PTY
+ *     {t:'shutdown'}        terminate this daemon (development cleanup only)
  */
 
 function arg(name) {
@@ -125,6 +126,16 @@ function cleanup() {
   if (process.platform !== 'win32') try { fs.unlinkSync(pipePath) } catch { /* ignore */ }
 }
 
+let shuttingDown = false
+function shutdown() {
+  if (shuttingDown) return
+  shuttingDown = true
+  try { ptyProc.kill() } catch { /* already exited */ }
+  try { server.close() } catch { /* ignore */ }
+  cleanup()
+  process.exit(0)
+}
+
 // ── IPC server ───────────────────────────────────────────────────────
 const server = net.createServer(socket => {
   clients.add(socket)
@@ -144,6 +155,7 @@ const server = net.createServer(socket => {
         const msg = JSON.parse(line)
         if (msg.t === 'i') ptyProc.write(msg.d)
         else if (msg.t === 'r') ptyProc.resize(msg.c, msg.r)
+        else if (msg.t === 'shutdown') shutdown()
       } catch { /* bad JSON, ignore */ }
     }
   })

--- a/src/main/browserViewManager.ts
+++ b/src/main/browserViewManager.ts
@@ -1945,7 +1945,13 @@ export function destroySessionBrowser(sessionId: string): void {
 
 // ─ IPC ────────────────────────────────────────────────────────────────
 
+let browserViewIpcRegistered = false
+
 export function registerBrowserViewIpc(): void {
+  // Browser view IPC is process-scoped. On macOS a Dock re-open creates a new
+  // BrowserWindow while the Electron main process is still alive.
+  if (browserViewIpcRegistered) return
+  browserViewIpcRegistered = true
   loadBrowserHistory()
   loadBrowserBookmarks()
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,6 +67,20 @@ function migrateLegacyScrollbackOnce(): void {
 
 let ptyManager: PtyManager
 let mainWindow: BrowserWindow
+let isQuitting = false
+
+/** electron-vite sends SIGINT/SIGTERM to the Electron child when its dev
+ * launcher is stopped with Ctrl+C. Explicitly close dev-only persistent PTY
+ * daemons before exiting, otherwise their Electron-in-Node-mode processes
+ * remain visible in the macOS Dock. */
+let devSignalShutdownStarted = false
+function shutdownForDevSignal(): void {
+  if (devSignalShutdownStarted) return
+  devSignalShutdownStarted = true
+  try { ptyManager?.flushAll() } catch { /* ignore */ }
+  try { ptyManager?.closeAll() } catch { /* ignore */ }
+  app.exit(0)
+}
 
 function createWindow(): BrowserWindow {
   ensureClaudeHudPluginDefaults()
@@ -96,6 +110,16 @@ function createWindow(): BrowserWindow {
     if (firstShow) {
       firstShow = false
       win.show()
+    }
+  })
+
+  // Keep the macOS application and its PTY sessions alive when the user closes
+  // its last window with Cmd+W / the traffic-light button. Dock activation then
+  // restores this same window instead of constructing a fresh application view.
+  win.on('close', (event) => {
+    if (process.platform === 'darwin' && !isQuitting) {
+      event.preventDefault()
+      win.hide()
     }
   })
 
@@ -212,6 +236,11 @@ function createWindow(): BrowserWindow {
 }
 
 app.whenReady().then(() => {
+  if (is.dev) {
+    process.once('SIGINT', shutdownForDevSignal)
+    process.once('SIGTERM', shutdownForDevSignal)
+  }
+
   // 允许渲染进程请求麦克风权限（语音识别功能）
   session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
     callback(permission === 'media')
@@ -262,11 +291,18 @@ app.whenReady().then(() => {
     setTimeout(() => checkForUpdates(), 3000)
   }
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow()
+      return
+    }
+    const win = !mainWindow.isDestroyed() ? mainWindow : BrowserWindow.getAllWindows()[0]
+    win?.show()
+    win?.focus()
   })
 })
 
 app.on('before-quit', () => {
+  isQuitting = true
   stopApiProxy()            // [2026-04-30] 关闭 API 容灾代理
   ptyManager?.flushAll()   // save scrollback
   ptyManager?.closeAll()   // kill PTY child processes so they don't keep the process alive
@@ -278,4 +314,3 @@ app.on('window-all-closed', () => {
   ptyManager?.closeAll()
   if (process.platform !== 'darwin') app.quit()
 })
-

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -174,6 +174,15 @@ export function registerIpcHandlers(
   sessionWatcher: ClaudeSessionWatcher,
   testManager: TestManager
 ): void {
+  // macOS keeps the main process alive after the last window closes. Reopening
+  // from the Dock creates fresh window-scoped managers, so replace the previous
+  // handlers before capturing those new instances. Without this, ipcMain.handle
+  // throws on the first duplicated channel (for example clipboard:saveImage).
+  for (const channel of new Set(Object.values(IPC))) {
+    ipcMain.removeHandler(channel)
+    ipcMain.removeAllListeners(channel)
+  }
+
   // [2026-04-30] ensure 合并 HUD 后再次写入 skip 标志，且须能读取 settingsStore（故放在 register 内）
   const scheduleEnsureClaudeHudAfterSession = (): void => {
     if (hudEnsureAfterSessionScheduled) return

--- a/src/main/ptyManager.ts
+++ b/src/main/ptyManager.ts
@@ -64,14 +64,11 @@ function looksLikeShellPrompt(buffer: string): boolean {
     //,  // Claude Code 提示符
     /╌/,  // 分隔线
     /───/,  // 分隔线
-    /⏵⏵/  // 选择菜单箭头
+    /⏵/  // 选择菜单箭头
   ]
   for (const pattern of claudeRunningPatterns) {
     if (pattern.test(tail)) return false
   }
-
-  // [2026-07-10] 调试：记录清理后的 tail 内容
-  console.log('[PTY] looksLikeShellPrompt tail:', JSON.stringify(tail.slice(-200)))
 
   if (/[A-Za-z]:\\[^\r\n]*>\s*$/m.test(tail)) return true
   if (process.platform !== 'win32') {
@@ -105,11 +102,16 @@ const PTY_ENV_STRIP = [
   'ANTHROPIC_AUTH_TOKEN',
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_MODEL',
+  // A shell-level 1M output budget can make compatible providers spend minutes
+  // preparing a trivial reply. Profiles do not manage this setting, so never
+  // inherit it into an embedded Claude Code session.
+  'ANTHROPIC_MAX_TOKENS',
   // [2026-06-01] 切换配置时防止旧配置的 model 变量残留（profile 无此字段时 filterEnvRecord 不会覆盖）
   'ANTHROPIC_DEFAULT_SONNET_MODEL',
   'ANTHROPIC_DEFAULT_HAIKU_MODEL',
   'ANTHROPIC_DEFAULT_OPUS_MODEL',
-  'CLAUDE_CODE_SUBAGENT_MODEL'
+  'CLAUDE_CODE_SUBAGENT_MODEL',
+  'CLAUDE_CODE_MAX_CONTEXT_TOKENS'
 ] as const
 
 /** [2026-05-08] Bun 默认装在 ~/.bun/bin；Electron 包壳启动时常继承不到用户后来在终端里改的 PATH，Telegram 等官方插件会 spawn bun 失败。 */
@@ -898,17 +900,6 @@ export class PtyManager {
       }
     }
 
-    // [2026-07-10] 诊断日志：posix_spawnp 失败时查看实际参数
-    console.log('[PTY] spawn params:', {
-      shell,
-      shellExists: existsSync(shell),
-      cwd: resolvedWorkdir,
-      cwdExists: existsSync(resolvedWorkdir),
-      customShell: customShell,
-      envSHELL: process.env.SHELL,
-      platform: process.platform
-    })
-
     const ptyProcess = pty.spawn(shell, [], {
       name: 'xterm-256color',
       cols: 120,
@@ -943,14 +934,12 @@ export class PtyManager {
     if (!shellOnly) {
       setTimeout(() => {
         session.firstAutoLaunchAt = Date.now()
-        const launchCmd = claudeLaunchLine(s, isWindows, {
+        ptyProcess.write(claudeLaunchLine(s, isWindows, {
           continueSession: effectiveResume,
           telegramChannelEnabled: session.telegramChannelLaunchEnabled,
           telegramStateDirAbs: session.telegramStateDirAbs,
           ptyShell: session.ptyShell
-        })
-        console.log('[PTY] first auto-launch:', launchCmd.trim())
-        ptyProcess.write(launchCmd)
+        }))
         session.claudeRunning = true
       }, 300)
     } else if (s.terminal?.useTmux) {
@@ -1004,51 +993,19 @@ export class PtyManager {
             session.claudeRunning = true
             session.firstAutoLaunchAt = Date.now()
             const settings = this.settingsStore.get()
-            const launchCmd = claudeLaunchLine(settings, process.platform === 'win32', {
-              telegramChannelEnabled: session.telegramChannelLaunchEnabled,
-              telegramStateDirAbs: session.telegramStateDirAbs,
-              ptyShell: session.ptyShell
-            })
-            console.log('[PTY] relaunch after --continue failure:', launchCmd.trim())
-            ptyProcess.write(launchCmd)
-          }
-        }, 300)
-        return
-      }
-
-      /* [2026-04-23] 曾在此检测就绪后发 `/resume`；已改为首启命令行 `claude --continue`（见 claudeLaunchLine）。 */
-
-      const sinceFirstLaunch = session.firstAutoLaunchAt ? Date.now() - session.firstAutoLaunchAt : 0
-      if (
-        session.claudeRunning &&
-        !session.relaunchPending &&
-        sinceFirstLaunch >= SHELL_RELAUNCH_GRACE_MS &&
-        looksLikeShellPrompt(session.buffer)
-      ) {
-        // [2026-07-10] 调试日志：记录触发重启的 buffer 内容
-        console.warn('[PTY] shell prompt detected, relaunching. sinceFirstLaunch:', sinceFirstLaunch, 'buffer:', JSON.stringify(session.buffer.slice(-200)))
-        session.claudeRunning = false
-        session.relaunchPending = true
-        session.buffer = ''
-        // Re-launch claude after a short delay
-        setTimeout(() => {
-          session.relaunchPending = false
-          if (this.sessions.has(sessionId)) {
-            session.claudeRunning = true
-            session.firstAutoLaunchAt = Date.now()
-            const settings = this.settingsStore.get()
-            // Relaunch without --continue: only the initial launch uses it
-            /* [2026-05-08] 原仅 claudeLaunchLine(settings, platform)，未带 telegramChannelEnabled，
-             * 首次启动若很快出现类似 cmd 提示符的输出，会误判「已回 shell」并在 ~500ms 再写一行 claude，
-             * 该行丢失 --channels，用户误以为 Telegram Channel 从未启用。 */
             ptyProcess.write(claudeLaunchLine(settings, process.platform === 'win32', {
               telegramChannelEnabled: session.telegramChannelLaunchEnabled,
               telegramStateDirAbs: session.telegramStateDirAbs,
               ptyShell: session.ptyShell
             }))
           }
-        }, 500)
+        }, 300)
+        return
       }
+
+      // Do not infer that Claude exited merely because output resembles a shell prompt.
+      // Terminal capability probes can produce the same sequences while Claude is starting;
+      // auto-writing a second command races with the first and can corrupt it (e.g. `ude`).
     })
 
     ptyProcess.onExit(({ exitCode }) => {
@@ -1324,8 +1281,17 @@ export class PtyManager {
     const session = this.sessions.get(sessionId)
     if (session) {
       if (session.daemonSocket) {
-        // Daemon sessions: disconnect but leave daemon running
-        try { session.daemonSocket.destroy() } catch { /* ignore */ }
+        // Packaged builds retain daemon sessions across app restarts. In dev,
+        // however, Ctrl+C should leave no Electron-in-Node-mode process (and
+        // therefore no stale Dock icon) behind.
+        if (!app.isPackaged) {
+          // end(data) flushes the shutdown command before closing the client
+          // side; write() followed by destroy() can discard it.
+          try { session.daemonSocket.end(JSON.stringify({ t: 'shutdown' }) + '\n') } catch { /* ignore */ }
+        } else {
+          // Daemon sessions: disconnect but leave the packaged-app daemon running.
+          try { session.daemonSocket.destroy() } catch { /* ignore */ }
+        }
       } else {
         this.flushScrollback(session)
         const proc = session.ptyProcess

--- a/src/main/settingsStore.ts
+++ b/src/main/settingsStore.ts
@@ -18,10 +18,20 @@ function filterEnvRecord(rec: Record<string, string | undefined | null>): Record
   )
 }
 
-/** [2026-06-22] 声明 1M 上下文：给模型名追加 [1m] 后缀（Claude Code 发给上游前会剥掉）。
- * 幂等——已带 [1m] 不重复追加；空模型名原样返回（由 filterEnvRecord 过滤）。 */
-function add1mSuffix(model: string, on?: boolean): string {
-  return on && model && !/\[1m\]$/i.test(model) ? `${model}[1m]` : model
+/**
+ * DashScope's coding endpoint accepts the raw model ID, but rejects a literal
+ * `[1m]` suffix. Keep profile values provider-safe even when an older saved
+ * profile already contains the suffix.
+ */
+function rawModelId(model: string): string {
+  return model.replace(/\[1m\]$/i, '')
+}
+
+/** Use Claude Code's documented context-window setting instead of model suffixes. */
+function contextWindow(profile: ApiProfile): string | undefined {
+  return profile.model1m || profile.sonnetModel1m || profile.opusModel1m
+    ? '1000000'
+    : undefined
 }
 export { DEFAULT_SETTINGS, createDefaultProfile }
 
@@ -139,13 +149,16 @@ export class SettingsStore {
     if (profile.isOfficial) return {}
     return filterEnvRecord({
       ANTHROPIC_AUTH_TOKEN: profile.authToken,
-      ANTHROPIC_API_KEY: profile.authToken,
+      // Claude Code treats AUTH_TOKEN and API_KEY as mutually exclusive.
+      // DashScope's Anthropic-compatible Claude Code integration uses
+      // ANTHROPIC_AUTH_TOKEN, so do not inject the same credential twice.
       ANTHROPIC_BASE_URL: profile.baseUrl,
-      ANTHROPIC_MODEL: add1mSuffix(profile.model, profile.model1m),
-      ANTHROPIC_DEFAULT_SONNET_MODEL: add1mSuffix(profile.sonnetModel, profile.sonnetModel1m),
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: profile.haikuModel,
-      ANTHROPIC_DEFAULT_OPUS_MODEL: add1mSuffix(profile.opusModel, profile.opusModel1m),
-      CLAUDE_CODE_SUBAGENT_MODEL: profile.subagentModel,
+      ANTHROPIC_MODEL: rawModelId(profile.model),
+      ANTHROPIC_DEFAULT_SONNET_MODEL: rawModelId(profile.sonnetModel),
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: rawModelId(profile.haikuModel),
+      ANTHROPIC_DEFAULT_OPUS_MODEL: rawModelId(profile.opusModel),
+      CLAUDE_CODE_SUBAGENT_MODEL: rawModelId(profile.subagentModel),
+      CLAUDE_CODE_MAX_CONTEXT_TOKENS: contextWindow(profile),
       CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: profile.disableExperimentalBetas ? '1' : '0'
     })
   }
@@ -156,13 +169,15 @@ export class SettingsStore {
     const baseUrl = proxyUrl ?? profile.baseUrl
     return filterEnvRecord({
       ANTHROPIC_AUTH_TOKEN: profile.authToken,
-      ANTHROPIC_API_KEY: profile.authToken,
+      // Keep this mutually exclusive with ANTHROPIC_AUTH_TOKEN. See the
+      // non-proxy path above for the DashScope compatibility rationale.
       ANTHROPIC_BASE_URL: baseUrl,
-      ANTHROPIC_MODEL: add1mSuffix(profile.model, profile.model1m),
-      ANTHROPIC_DEFAULT_SONNET_MODEL: add1mSuffix(profile.sonnetModel, profile.sonnetModel1m),
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: profile.haikuModel,
-      ANTHROPIC_DEFAULT_OPUS_MODEL: add1mSuffix(profile.opusModel, profile.opusModel1m),
-      CLAUDE_CODE_SUBAGENT_MODEL: profile.subagentModel,
+      ANTHROPIC_MODEL: rawModelId(profile.model),
+      ANTHROPIC_DEFAULT_SONNET_MODEL: rawModelId(profile.sonnetModel),
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: rawModelId(profile.haikuModel),
+      ANTHROPIC_DEFAULT_OPUS_MODEL: rawModelId(profile.opusModel),
+      CLAUDE_CODE_SUBAGENT_MODEL: rawModelId(profile.subagentModel),
+      CLAUDE_CODE_MAX_CONTEXT_TOKENS: contextWindow(profile),
       CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: profile.disableExperimentalBetas ? '1' : '0'
     })
   }

--- a/src/renderer/src/components/settings/SettingsPanel.tsx
+++ b/src/renderer/src/components/settings/SettingsPanel.tsx
@@ -843,7 +843,7 @@ export function SettingsPanel(): React.ReactElement {
             />
           </Field>
 
-          {/* All Models — 默认/Sonnet/Opus 行带「1M」声明勾选（追加 [1m] 后缀），仅第三方配置生效 */}
+          {/* All Models — 默认/Sonnet/Opus 行带「1M」上下文声明，仅第三方配置生效 */}
           {(
             [
               ['model', lang === 'zh' ? '默认模型' : 'Default Model', 'ANTHROPIC_MODEL', 'model1m'],
@@ -865,7 +865,7 @@ export function SettingsPanel(): React.ReactElement {
                 {oneMKey && (
                   <label
                     className="flex items-center gap-1 text-[10px] text-claude-muted whitespace-nowrap cursor-pointer select-none"
-                    title={lang === 'zh' ? '声明该模型支持 1M 上下文（发给上游前自动去掉 [1m]）' : 'Declare 1M context for this model ([1m] is stripped before reaching your provider)'}
+                    title={lang === 'zh' ? '启用 1M 上下文窗口（不会把 [1m] 后缀发送给上游）' : 'Enable a 1M context window without sending a [1m] suffix upstream'}
                   >
                     <input
                       type="checkbox"
@@ -1434,7 +1434,7 @@ function ProfileEditor({
             />
           </Field>
 
-          {/* Models — 默认/Sonnet/Opus 行带「1M」声明勾选（追加 [1m] 后缀），仅第三方配置生效 */}
+          {/* Models — 默认/Sonnet/Opus 行带「1M」上下文声明，仅第三方配置生效 */}
           {(
             [
               ['model', lang === 'zh' ? '默认模型' : 'Default Model', 'ANTHROPIC_MODEL', 'model1m'],
@@ -1456,7 +1456,7 @@ function ProfileEditor({
                 {oneMKey && (
                   <label
                     className="flex items-center gap-1 text-[10px] text-claude-muted whitespace-nowrap cursor-pointer select-none"
-                    title={lang === 'zh' ? '声明该模型支持 1M 上下文（发给上游前自动去掉 [1m]）' : 'Declare 1M context for this model ([1m] is stripped before reaching your provider)'}
+                    title={lang === 'zh' ? '启用 1M 上下文窗口（不会把 [1m] 后缀发送给上游）' : 'Enable a 1M context window without sending a [1m] suffix upstream'}
                   >
                     <input
                       type="checkbox"

--- a/src/renderer/src/components/terminal/TerminalPaneHeader.tsx
+++ b/src/renderer/src/components/terminal/TerminalPaneHeader.tsx
@@ -448,7 +448,10 @@ export function TerminalPaneHeader({ sessionId, focused }: Props): React.ReactEl
             </HeaderBtn>
           )}
           {/* [2026-05-27] 刷新终端画面（TUI 应用切回后乱码时手动补救） */}
-          <HeaderBtn title="刷新终端 (Refresh)" onClick={() => wakeTerminal(sessionId)}>
+          <HeaderBtn
+            title="刷新终端 (Refresh)"
+            onClick={() => wakeTerminal(sessionId, { notifyPtyResize: false })}
+          >
             <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
               <path d="M9.5 5.5A4 4 0 1 1 8 2.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
               <path d="M8 1v2h-2" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>

--- a/src/renderer/src/components/terminal/XTerminal.tsx
+++ b/src/renderer/src/components/terminal/XTerminal.tsx
@@ -249,12 +249,20 @@ export function getTerminalTextarea(sessionId: string): HTMLTextAreaElement | nu
 }
 
 /** [2026-05-07] 浮窗挂载同一 xterm 时，布局稳定前 fit 可能吃到 0 尺寸；显式唤醒重绘 */
-export function wakeTerminal(sessionId: string): void {
+export function wakeTerminal(sessionId: string, options?: { notifyPtyResize?: boolean }): void {
   const entry = terminals.get(sessionId)
   if (!entry) return
   try {
     entry.fitAddon.fit()
-    window.electronAPI?.resizePty(sessionId, entry.term.cols, entry.term.rows)
+    // A visual-only refresh must not synthesize SIGWINCH. Claude Code responds
+    // to a resize by querying terminal capabilities/cursor position; if it exits
+    // during that exchange, those response sequences can be echoed by the shell.
+    // Real layout changes are already reported by the resize observers.
+    // Resizing is opt-in: the mounted terminal's ResizeObserver reports real
+    // geometry changes. Callers of this helper generally only need a repaint.
+    if (options?.notifyPtyResize === true) {
+      window.electronAPI?.resizePty(sessionId, entry.term.cols, entry.term.rows)
+    }
   } catch {
     // ignore hidden/detached terminal fit errors
   }

--- a/src/renderer/src/store/sessionStore.ts
+++ b/src/renderer/src/store/sessionStore.ts
@@ -551,7 +551,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     if (result.scrollback) {
       preFillTerminal(result.sessionId, result.scrollback)
     }
-    // [2026-06-02] 切换配置后终端可能显示异常，延迟 wake 确保 XTerminal 完成挂载
+    // [2026-06-02] 切换配置后终端可能显示异常，延迟重绘确保 XTerminal 完成挂载。
+    // 尺寸变化由 XTerminal 的 ResizeObserver 上报；这里不能额外发送 SIGWINCH，
+    // 否则 Claude Code 的终端查询响应可能在 shell 中回显成 ^[[?...R。
     setTimeout(() => wakeTerminal(result.sessionId), 200)
     setTimeout(() => wakeTerminal(result.sessionId), 600)
   },


### PR DESCRIPTION
## What changed

- Keep the macOS window and PTY sessions alive across Cmd+W and Dock activation.
- Prevent duplicate IPC handler registration when the window is restored.
- Shut down development PTY daemons when `npm run dev` is stopped.
- Make terminal refresh visual-only so it does not emit stray resize/control sequences.
- Prevent duplicate Claude auto-launches that could corrupt the launch command.
- Avoid conflicting Anthropic credentials and inherited oversized output budgets.
- Configure 1M context independently from the upstream model ID.
- Update Electron and the development launcher for the current macOS runtime.

## Why

On macOS, closing and reopening the app could recreate process-scoped handlers, leave development Electron processes in the Dock, or race a second Claude launch into the PTY. Terminal refreshes could also surface terminal capability responses as shell text. Conflicting API environment variables made third-party Anthropic-compatible providers unreliable.

## User impact

The app now restores the existing macOS window cleanly, exits development processes reliably, refreshes terminals without corrupt output, starts Claude once, and supplies a consistent API environment.

## Validation

- `npm run build`
- `git diff --check`
- Manual macOS development-process shutdown and Dock restore checks
